### PR TITLE
fix: wire up advanced.ffmpeg_options from config (was dead code)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -94,7 +94,12 @@ logging:
 
 advanced:
   ffmpeg_debug: false
-  ffmpeg_options: 'rtsp_transport;tcp|video_codec;h265|hwaccel;vaapi|hwaccel_device;/dev/dri/renderD128|pixel_format;yuv420p'
+  # FFMPEG capture options (format: key;value|key;value - passed to OPENCV_FFMPEG_CAPTURE_OPTIONS)
+  # Default (auto-detect codec): 'rtsp_transport;tcp'
+  # H.264 forced (RPi4, most cameras): 'rtsp_transport;tcp|video_codec;h264'
+  # H.265 + VAAPI hw accel (x86 with GPU): 'rtsp_transport;tcp|video_codec;h265|hwaccel;vaapi|hwaccel_device;/dev/dri/renderD128'
+  # NOTE: VAAPI does NOT work on RPi4 even if /dev/dri/renderD128 exists
+  ffmpeg_options: 'rtsp_transport;tcp|video_codec;h264'
   camera_init_wait: 2
   polling_interval: 0.1
   reconnect_attempts: 3

--- a/src/camera_service.py
+++ b/src/camera_service.py
@@ -37,9 +37,8 @@ from logging_utils import RateLimitedLogger, CameraStateTracker
 
 from version import VERSION
 
-# Force FFMPEG to use TCP transport for all RTSP connections
-# Let codec auto-detect - cameras may use H.264 or H.265
-os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = "rtsp_transport;tcp"
+# FFMPEG capture options are set from config in CameraService.setup_cameras()
+# Default: "rtsp_transport;tcp" (TCP transport, codec auto-detect)
 
 class CameraInstance:
     """Represents a single camera instance with its own configuration and state"""
@@ -335,6 +334,11 @@ class CameraService:
     def setup_cameras(self):
         """Initialize and configure all cameras from config"""
         try:
+            # Set FFMPEG options from config (default: TCP transport with codec auto-detect)
+            ffmpeg_opts = self.config.get('advanced', {}).get('ffmpeg_options', 'rtsp_transport;tcp')
+            os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = ffmpeg_opts
+            self.logger.info(f"FFMPEG capture options: {ffmpeg_opts}")
+
             # Set FFMPEG debug based on config
             os.environ["OPENCV_FFMPEG_DEBUG"] = "1" if self.config.get('advanced', {}).get('ffmpeg_debug', False) else "0"
             
@@ -692,6 +696,14 @@ class CameraService:
             old_val = old_config.get('advanced', {}).get(key)
             if new_val is not None and new_val != old_val:
                 changes.append(f"advanced.{key}: {old_val} -> {new_val}")
+
+        # 4b. FFMPEG options (applied immediately via env var)
+        new_ffmpeg = new_config.get('advanced', {}).get('ffmpeg_options')
+        old_ffmpeg = old_config.get('advanced', {}).get('ffmpeg_options')
+        if new_ffmpeg is not None and new_ffmpeg != old_ffmpeg:
+            os.environ["OPENCV_FFMPEG_CAPTURE_OPTIONS"] = new_ffmpeg
+            changes.append(f"advanced.ffmpeg_options: {old_ffmpeg} -> {new_ffmpeg}")
+            restart_required.append('advanced.ffmpeg_options (active cameras need reconnect)')
 
         # Check for changes that require restart (warn only)
         if new_config.get('cameras') != old_config.get('cameras'):


### PR DESCRIPTION
## Problem

`advanced.ffmpeg_options` in `config.yaml` was silently ignored. The env var `OPENCV_FFMPEG_CAPTURE_OPTIONS` was hardcoded at module level (`rtsp_transport;tcp`) before config was loaded, so any user configuration was never applied.

## Changes

- Move `OPENCV_FFMPEG_CAPTURE_OPTIONS` setup from module level to `setup_cameras()`, after config is loaded
- Read `advanced.ffmpeg_options` from config (default: `rtsp_transport;tcp`)
- Log the effective value at startup
- Add hot-reload support in `handle_reload()` (changes take effect on SIGHUP, with reconnect warning)
- Document available options in `config.yaml` example with comments

## Notes

- VAAPI does **not** work on RPi4 even if `/dev/dri/renderD128` exists
- `video_codec;h264` is required to avoid `0x0 @ 90000fps` init mis-detect with Hikvision cameras
- Decode warnings (`chroma_log2_weight_denom out of range`) are non-fatal — occasional frame drops only

## Tested

RPi4 (saicam1) with Hikvision H.264 camera, 2304x1296 @ 15fps, config `rtsp_transport;tcp|video_codec;h264`.

AI-assisted development